### PR TITLE
fix: preserve preset list scroll

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -271,9 +271,17 @@ function selectPreset(preset) {
   selectedMetadata = preset.metadata ?? {};
   renderCurrentPalette();
   updateApplyButton();
-  renderColors();
+  syncSelectedPresetButtonState();
   queuePersistDraft({ immediate: true });
   sendSelectedSchemePreview();
+}
+
+function syncSelectedPresetButtonState() {
+  const selectedPresetId = selectedPreset?.id ?? "";
+
+  for (const button of colorListNode.querySelectorAll("[data-preset-id]")) {
+    button.setAttribute("aria-pressed", String(button.dataset.presetId === selectedPresetId));
+  }
 }
 
 function selectFont() {

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -11,12 +11,61 @@ function extractFunctionBody(source, functionName) {
   assert.notEqual(bodyStart, -1, `${functionName}() should have a body`);
 
   let depth = 0;
+  let stringQuote = null;
+  let commentType = null;
   for (let index = bodyStart; index < source.length; index += 1) {
-    if (source[index] === "{") {
+    const char = source[index];
+    const nextChar = source[index + 1];
+
+    if (commentType === "line") {
+      if (char === "\n") {
+        commentType = null;
+      }
+      continue;
+    }
+
+    if (commentType === "block") {
+      if (char === "*" && nextChar === "/") {
+        commentType = null;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (stringQuote) {
+      if (char === "\\") {
+        index += 1;
+        continue;
+      }
+
+      if (char === stringQuote) {
+        stringQuote = null;
+      }
+      continue;
+    }
+
+    if (char === "/" && nextChar === "/") {
+      commentType = "line";
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && nextChar === "*") {
+      commentType = "block";
+      index += 1;
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      stringQuote = char;
+      continue;
+    }
+
+    if (char === "{") {
       depth += 1;
     }
 
-    if (source[index] === "}") {
+    if (char === "}") {
       depth -= 1;
     }
 

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -3,6 +3,31 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 
+function extractFunctionBody(source, functionName) {
+  const signatureIndex = source.indexOf(`function ${functionName}(`);
+  assert.notEqual(signatureIndex, -1, `${functionName}() should exist`);
+
+  const bodyStart = source.indexOf("{", signatureIndex);
+  assert.notEqual(bodyStart, -1, `${functionName}() should have a body`);
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    if (source[index] === "{") {
+      depth += 1;
+    }
+
+    if (source[index] === "}") {
+      depth -= 1;
+    }
+
+    if (depth === 0) {
+      return source.slice(bodyStart + 1, index);
+    }
+  }
+
+  assert.fail(`${functionName}() body should close`);
+}
+
 test("extension-only scope does not include marketplace handoff surfaces", async () => {
   const packageJson = JSON.parse(await readFile("package.json", "utf8"));
   const manifest = JSON.parse(await readFile("extension/manifest.json", "utf8"));
@@ -101,6 +126,7 @@ test("extension popup opens the color picker directly from current palette swatc
 test("extension popup keeps scrolling inside the color list", async () => {
   const popupCss = await readFile("extension/popup.css", "utf8");
   const popupJs = await readFile("extension/popup.js", "utf8");
+  const selectPresetBody = extractFunctionBody(popupJs, "selectPreset");
 
   assert.doesNotMatch(popupJs, /classList\.add\("has-controls"\)/);
   assert.doesNotMatch(popupCss, /body\.has-controls/);
@@ -115,6 +141,9 @@ test("extension popup keeps scrolling inside the color list", async () => {
   assert.match(popupJs, /renderColors\(\{ scrollIntoView: true \}\)/);
   assert.match(popupJs, /function renderColors\(\{ scrollIntoView = false \} = \{\}\)/);
   assert.match(popupJs, /if \(scrollIntoView\) \{\s*scrollSelectedPresetIntoView\(\);\s*\}/s);
+  assert.match(popupJs, /function syncSelectedPresetButtonState\(\)/);
+  assert.match(selectPresetBody, /syncSelectedPresetButtonState\(\)/);
+  assert.doesNotMatch(selectPresetBody, /renderColors\(/);
   assert.doesNotMatch(popupJs, /colorListNode\.replaceChildren\(\.\.\.matches\.map\(renderColorButton\)\);\s*scrollSelectedPresetIntoView\(\);/s);
   assert.match(popupJs, /let persistDraftTimeout = null;/);
   assert.match(popupJs, /clearPendingDraftWrite\(\)/);


### PR DESCRIPTION
## Summary
- Preserve the color preset list scroll position when selecting a preset.
- Update only the existing preset button selected state instead of rebuilding the whole list on click.
- Add a popup workflow regression assertion for the click path.

## Verification
- `node --test test/pages-workflow.test.mjs`
- `pnpm test`
- Browser tmp profile check: selected Jellybeans with `scrollTop` unchanged at 19692 before and after click.

## Risk
- Low. Initial popup auto-scroll still uses `renderColors({ scrollIntoView: true })`; only the user click path stops rebuilding the list.