### PR TITLE
fix: route popup to term ptt tab

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -140,7 +140,11 @@ async function routeToTermPtt() {
     if (targetTab?.id) {
       await chrome.tabs.update(targetTab.id, { active: true });
       if (typeof targetTab.windowId === "number" && chrome.windows?.update) {
-        await chrome.windows.update(targetTab.windowId, { focused: true });
+        try {
+          await chrome.windows.update(targetTab.windowId, { focused: true });
+        } catch {
+          // Window focus is best-effort; the tab activation above is the primary route.
+        }
       }
     } else {
       await chrome.tabs.create({ url: TERM_PTT_URL, active: true });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -10,6 +10,8 @@ const paletteStripNode = document.getElementById("paletteStrip");
 const colorListNode = document.getElementById("colorList");
 const applyButton = document.getElementById("applyButton");
 
+const TERM_PTT_URL = "https://term.ptt.cc/";
+const TERM_PTT_PATTERN = "https://term.ptt.cc/*";
 const DEFAULT_COLORS_ID = "term-ptt-default";
 const DEFAULT_FONT_ID = "term-ptt-default";
 const defaultColorsPreset = TermPttAppearanceState.defaultColorsPreset ?? {
@@ -78,8 +80,8 @@ async function init() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   activeTab = tab;
 
-  if (!activeTab?.id || !activeTab.url?.startsWith("https://term.ptt.cc/")) {
-    statusNode.textContent = "Open term.ptt.cc to preview colors.";
+  if (!isTermPttTab(activeTab)) {
+    await routeToTermPtt();
     return;
   }
 
@@ -123,6 +125,31 @@ async function init() {
   renderColors({ scrollIntoView: true });
   updateApplyButton();
   previewSelectedAppearance();
+}
+
+function isTermPttTab(tab) {
+  return Boolean(tab?.id && tab.url?.startsWith(TERM_PTT_URL));
+}
+
+async function routeToTermPtt() {
+  statusNode.textContent = "Opening term.ptt.cc...";
+
+  try {
+    const [targetTab] = await chrome.tabs.query({ url: TERM_PTT_PATTERN });
+
+    if (targetTab?.id) {
+      await chrome.tabs.update(targetTab.id, { active: true });
+      if (typeof targetTab.windowId === "number" && chrome.windows?.update) {
+        await chrome.windows.update(targetTab.windowId, { focused: true });
+      }
+    } else {
+      await chrome.tabs.create({ url: TERM_PTT_URL, active: true });
+    }
+
+    window.close();
+  } catch {
+    statusNode.textContent = "Could not open term.ptt.cc.";
+  }
 }
 
 function getAppearanceDraft() {

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -7,7 +7,9 @@ const outputPath = path.resolve("dist/term-ptt-custom-theme.zip");
 await mkdir(path.dirname(outputPath), { recursive: true });
 await rm(outputPath, { force: true });
 
-await run("zip", ["-qr", outputPath, "."], { cwd: "extension" });
+await run("zip", ["-qr", outputPath, ".", "-x", ".DS_Store", "*/.DS_Store", "__MACOSX/*"], {
+  cwd: "extension",
+});
 
 console.log(`Packaged extension to ${outputPath}`);
 

--- a/test/package-verifier.test.mjs
+++ b/test/package-verifier.test.mjs
@@ -25,6 +25,9 @@ test("verify script validates the packaged extension zip after packaging", async
   assert.match(verifierScript, /assets\/fonts\.json/);
   assert.match(verifierScript, /extractPopupLocalReferences/);
   assert.match(packageScript, /Missing required command/);
+  assert.match(packageScript, /"\.DS_Store"/);
+  assert.match(packageScript, /"\*\/\.DS_Store"/);
+  assert.match(packageScript, /"__MACOSX\/\*"/);
   assert.match(readme, /requires the system `zip` command/);
 });
 

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -183,7 +183,10 @@ test("extension popup routes non-term pages to term.ptt.cc", async () => {
   assert.match(initBody, /if \(!isTermPttTab\(activeTab\)\) \{\s*await routeToTermPtt\(\);\s*return;\s*\}/s);
   assert.match(routeBody, /chrome\.tabs\.query\(\{ url: TERM_PTT_PATTERN \}\)/);
   assert.match(routeBody, /chrome\.tabs\.update\(targetTab\.id, \{ active: true \}\)/);
-  assert.match(routeBody, /chrome\.windows\.update\(targetTab\.windowId, \{ focused: true \}\)/);
+  assert.match(
+    routeBody,
+    /if \(typeof targetTab\.windowId === "number" && chrome\.windows\?\.update\) \{\s*try \{\s*await chrome\.windows\.update\(targetTab\.windowId, \{ focused: true \}\);\s*\} catch \{/s,
+  );
   assert.match(routeBody, /chrome\.tabs\.create\(\{ url: TERM_PTT_URL, active: true \}\)/);
   assert.match(routeBody, /window\.close\(\)/);
   assert.match(routeBody, /statusNode\.textContent = "Could not open term\.ptt\.cc\."/);

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -172,6 +172,23 @@ test("extension popup opens the color picker directly from current palette swatc
   assert.doesNotMatch(popupCss, /:has\(\.palette-editor/);
 });
 
+test("extension popup routes non-term pages to term.ptt.cc", async () => {
+  const popupJs = await readFile("extension/popup.js", "utf8");
+  const initBody = extractFunctionBody(popupJs, "init");
+  const routeBody = extractFunctionBody(popupJs, "routeToTermPtt");
+
+  assert.match(popupJs, /const TERM_PTT_URL = "https:\/\/term\.ptt\.cc\/";/);
+  assert.match(popupJs, /const TERM_PTT_PATTERN = "https:\/\/term\.ptt\.cc\/\*";/);
+  assert.match(popupJs, /function isTermPttTab\(tab\)/);
+  assert.match(initBody, /if \(!isTermPttTab\(activeTab\)\) \{\s*await routeToTermPtt\(\);\s*return;\s*\}/s);
+  assert.match(routeBody, /chrome\.tabs\.query\(\{ url: TERM_PTT_PATTERN \}\)/);
+  assert.match(routeBody, /chrome\.tabs\.update\(targetTab\.id, \{ active: true \}\)/);
+  assert.match(routeBody, /chrome\.windows\.update\(targetTab\.windowId, \{ focused: true \}\)/);
+  assert.match(routeBody, /chrome\.tabs\.create\(\{ url: TERM_PTT_URL, active: true \}\)/);
+  assert.match(routeBody, /window\.close\(\)/);
+  assert.match(routeBody, /statusNode\.textContent = "Could not open term\.ptt\.cc\."/);
+});
+
 test("extension popup keeps scrolling inside the color list", async () => {
   const popupCss = await readFile("extension/popup.css", "utf8");
   const popupJs = await readFile("extension/popup.js", "utf8");


### PR DESCRIPTION
## Summary
- Route popup opens from non-term.ptt pages to an existing term.ptt.cc tab, or create one when absent.
- Keep the existing term.ptt popup customization flow unchanged.
- Exclude macOS metadata files from the packaged extension zip so local release verification stays clean.

## Verification
- pnpm test
- node --test test/package-verifier.test.mjs
- pnpm verify
- Manual tmp Chromium profile smoke test for create-tab and focus-existing-tab flows.