### PR TITLE
Polish popup preset previews

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,11 +1,14 @@
 :root {
-  color-scheme: light;
-  --bg: #fffdf8;
-  --panel: #f5f1e8;
-  --ink: #1e2724;
-  --muted: #63706a;
-  --line: #d9d1c4;
-  --accent: #0f766e;
+  color-scheme: dark;
+  --bg: #07100d;
+  --panel: #101a16;
+  --field: #0c1512;
+  --ink: #e8f2ed;
+  --muted: #9ab0a7;
+  --line: #263832;
+  --line-strong: #3f5a51;
+  --accent: #11b89f;
+  --accent-strong: #5ff2d8;
 }
 
 * {
@@ -16,6 +19,7 @@ html,
 body {
   width: 380px;
   height: 600px;
+  background: var(--bg);
   overflow: hidden;
 }
 
@@ -23,7 +27,7 @@ body {
   margin: 0;
   background: var(--bg);
   color: var(--ink);
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
 }
 
 button,
@@ -37,24 +41,27 @@ select {
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  padding: 14px;
+  padding: 12px;
 }
 
 .header {
   flex: 0 0 auto;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
 }
 
 h1 {
   margin: 0;
-  font-size: 17px;
+  color: var(--ink);
+  font-size: 16px;
   line-height: 1.2;
 }
 
 p {
   margin: 4px 0 0;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .controls {
@@ -72,10 +79,10 @@ p {
 .font-field {
   display: grid;
   flex: 0 0 auto;
-  gap: 6px;
-  margin-bottom: 10px;
+  gap: 5px;
+  margin-bottom: 9px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
 }
 
@@ -83,26 +90,39 @@ p {
 .font-field select {
   width: 100%;
   border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 9px 10px;
-  background: #fff;
+  border-radius: 5px;
+  padding: 8px 9px;
+  background: var(--field);
+  color: var(--ink);
+}
+
+.search input::placeholder {
+  color: #8da097;
+  opacity: 1;
+}
+
+.search input:focus-visible,
+.font-field select:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid rgba(17, 184, 159, 0.36);
+  outline-offset: 1px;
 }
 
 .font-field small {
   color: var(--muted);
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 500;
 }
 
 .current-palette {
   display: grid;
   flex: 0 0 auto;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: 7px;
+  margin-bottom: 10px;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: #fff;
-  padding: 10px;
+  border-radius: 6px;
+  background: var(--panel);
+  padding: 9px;
 }
 
 .palette-header {
@@ -119,15 +139,16 @@ p {
 }
 
 .palette-title span {
-  color: var(--muted);
-  font-size: 11px;
+  color: var(--accent-strong);
+  font-size: 10px;
   font-weight: 800;
   text-transform: uppercase;
 }
 
 .palette-title strong {
   overflow: hidden;
-  font-size: 14px;
+  color: var(--ink);
+  font-size: 13px;
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -141,35 +162,35 @@ p {
 }
 
 .modified-badge {
-  border: 1px solid #c9861b;
+  border: 1px solid #e7b84f;
   border-radius: 999px;
   padding: 2px 7px;
-  background: #fff8e6;
-  color: #7a4b00;
-  font-size: 11px;
+  background: #332817;
+  color: #f7d275;
+  font-size: 10px;
   font-weight: 800;
 }
 
 .inline-reset {
   border: 0;
-  border-radius: 6px;
+  border-radius: 5px;
   background: transparent;
-  color: var(--accent);
-  font-size: 12px;
+  color: var(--accent-strong);
+  font-size: 11px;
   font-weight: 800;
   cursor: pointer;
 }
 
 .inline-reset:focus-visible,
 .palette-swatch:focus-visible {
-  outline: 2px solid #006bd6;
+  outline: 2px solid var(--accent-strong);
   outline-offset: 2px;
 }
 
 .palette-strip {
   display: grid;
   grid-template-columns: repeat(16, minmax(0, 1fr));
-  gap: 3px;
+  gap: 4px;
 }
 
 .palette-picker {
@@ -182,8 +203,8 @@ p {
   aspect-ratio: 1;
   width: 100%;
   min-width: 0;
-  border: 1px solid rgba(0, 0, 0, 0.18);
-  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 2px;
   padding: 0;
   cursor: pointer;
 }
@@ -201,7 +222,7 @@ p {
 .palette-default-note {
   grid-column: 1 / -1;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
 }
 
@@ -210,7 +231,7 @@ p {
   flex: 1 1 auto;
   min-height: 0;
   align-content: start;
-  gap: 8px;
+  gap: 5px;
   overflow-x: hidden;
   overflow-y: auto;
   padding-right: 0;
@@ -220,51 +241,148 @@ p {
 .color-button {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
-  gap: 8px;
   align-items: start;
   width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: #fff;
-  padding: 9px;
-  color: var(--ink);
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 0;
+  color: inherit;
   text-align: left;
   cursor: pointer;
 }
 
-.color-label {
-  min-width: 0;
+.color-button:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
 }
 
-.color-button[aria-pressed="true"] {
+.color-button[aria-pressed="true"] .preset-preview {
   border-color: var(--accent);
-  background: #edf8f5;
-  box-shadow: inset 0 0 0 1px var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
-.color-button strong {
-  display: block;
-  font-size: 13px;
+.color-button:hover .preset-preview {
+  border-color: var(--line-strong);
 }
 
-.color-button span {
-  color: var(--muted);
-  font-size: 11px;
-  overflow-wrap: anywhere;
+.color-button[aria-pressed="true"]:hover .preset-preview {
+  border-color: var(--accent);
 }
 
-.swatches {
+.color-button:active .preset-preview {
+  transform: translateY(1px);
+}
+
+.preset-preview {
   display: grid;
-  grid-template-columns: repeat(8, 12px);
-  gap: 3px;
-  justify-content: start;
+  min-width: 0;
+  gap: 5px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 5px;
+  background: #151515;
+  color: #f5f5f5;
+  padding: 7px 8px;
+  transition:
+    border-color 140ms ease-out,
+    box-shadow 140ms ease-out,
+    transform 140ms ease-out;
 }
 
-.swatches i {
-  width: 12px;
-  height: 12px;
-  border: 1px solid rgba(0, 0, 0, 0.14);
-  border-radius: 3px;
+.preset-preview-default {
+  background: #16201c;
+  color: #eeeeee;
+}
+
+.preset-preview-article {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 6px;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.preset-preview-marker {
+  flex: 0 0 auto;
+  font-size: 10px;
+}
+
+.preset-preview-date {
+  flex: 0 0 auto;
+  opacity: 0.72;
+  font-size: 10px;
+}
+
+.preset-preview-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preset-preview-samples {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  overflow: hidden;
+  font-size: 10px;
+  line-height: 1.25;
+  white-space: nowrap;
+}
+
+.preset-preview-source,
+.ptt-color-sample-label {
+  display: inline-grid;
+  flex: 0 0 auto;
+  min-height: 1.35em;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, currentColor 34%, transparent);
+  border-radius: 2px;
+  font-weight: 800;
+}
+
+.preset-preview-source {
+  max-width: 116px;
+  overflow: hidden;
+  padding: 0 5px;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  opacity: 0.78;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ptt-color-sample-group {
+  display: inline-flex;
+  flex: 0 0 auto;
+  min-width: 0;
+  align-items: center;
+  gap: 1px;
+}
+
+.ptt-color-sample-label {
+  padding: 0 3px;
+  color: color-mix(in srgb, currentColor 84%, transparent);
+  background: color-mix(in srgb, currentColor 7%, transparent);
+}
+
+.ptt-color-sample {
+  display: inline-grid;
+  flex: 0 0 auto;
+  width: 1.55em;
+  height: 1.45em;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 1px;
+  font-size: 9px;
+  font-weight: 800;
+  line-height: 1;
 }
 
 .actions {
@@ -272,11 +390,11 @@ p {
   flex: 0 0 auto;
   grid-template-columns: 1fr;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 10px;
 }
 
 .actions button {
-  border-radius: 6px;
+  border-radius: 5px;
   padding: 9px 10px;
   font-weight: 800;
   cursor: pointer;
@@ -285,12 +403,32 @@ p {
 #applyButton {
   border: 1px solid var(--accent);
   background: var(--accent);
-  color: #fff;
+  color: #03110e;
 }
 
 #applyButton:disabled {
   border-color: var(--line);
-  background: var(--panel);
+  background: #121b18;
   color: var(--muted);
   cursor: not-allowed;
+}
+
+#applyButton:not(:disabled):hover {
+  border-color: var(--accent-strong);
+  background: var(--accent-strong);
+}
+
+#applyButton:focus-visible {
+  outline: 2px solid rgba(95, 242, 216, 0.5);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preset-preview {
+    transition: none;
+  }
+
+  .color-button:active .preset-preview {
+    transform: none;
+  }
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -25,7 +25,6 @@ body {
 
 body {
   margin: 0;
-  background: var(--bg);
   color: var(--ink);
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
 }
@@ -104,7 +103,7 @@ p {
 .search input:focus-visible,
 .font-field select:focus-visible {
   border-color: var(--accent);
-  outline: 2px solid rgba(17, 184, 159, 0.36);
+  outline: 2px solid color-mix(in srgb, var(--accent) 36%, transparent);
   outline-offset: 1px;
 }
 
@@ -290,11 +289,6 @@ p {
     transform 140ms ease-out;
 }
 
-.preset-preview-default {
-  background: #16201c;
-  color: #eeeeee;
-}
-
 .preset-preview-article {
   display: flex;
   min-width: 0;
@@ -419,7 +413,7 @@ p {
 }
 
 #applyButton:focus-visible {
-  outline: 2px solid rgba(95, 242, 216, 0.5);
+  outline: 2px solid color-mix(in srgb, var(--accent-strong) 50%, transparent);
   outline-offset: 2px;
 }
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -384,6 +384,7 @@ function renderPresetArticleLine({ markerColor, title, source }) {
   const marker = document.createElement("span");
   marker.className = "preset-preview-marker";
   marker.style.color = markerColor;
+  marker.setAttribute("aria-hidden", "true");
   marker.textContent = "●";
 
   const date = document.createElement("span");

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -60,6 +60,71 @@ const schemeLabels = {
   brightWhite: "Bright White",
 };
 
+const defaultPttScheme = {
+  black: "#000000",
+  red: "#800000",
+  green: "#008000",
+  yellow: "#808000",
+  blue: "#000080",
+  purple: "#800080",
+  cyan: "#008080",
+  white: "#c0c0c0",
+  brightBlack: "#808080",
+  brightRed: "#ff0000",
+  brightGreen: "#00ff00",
+  brightYellow: "#ffff00",
+  brightBlue: "#0000ff",
+  brightPurple: "#ff00ff",
+  brightCyan: "#00ffff",
+  brightWhite: "#ffffff",
+};
+
+const pttBrightForegroundKeys = [
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightPurple",
+  "brightCyan",
+  "brightWhite",
+];
+
+const pttDarkBackgroundKeys = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "purple",
+  "cyan",
+  "brightBlack",
+];
+
+const pttPreviewSampleGroups = [
+  {
+    label: "黑底",
+    cells: pttBrightForegroundKeys.map((key) => ({
+      text: "文",
+      fgKey: key,
+      bgKey: "black",
+      pttClass: `q${schemeKeys.indexOf(key)} b0/body`,
+    })),
+  },
+  {
+    label: "白字",
+    cells: pttDarkBackgroundKeys.map((key) => {
+      const bgIndex = schemeKeys.indexOf(key);
+      return {
+        text: "白",
+        fgKey: "brightWhite",
+        bgKey: key,
+        pttClass: `q15 ${bgIndex === 0 ? "b0/body" : `b${bgIndex}`}`,
+      };
+    }),
+  },
+];
+
 let activeTab = null;
 let port = null;
 let registry = [];
@@ -272,28 +337,134 @@ function renderColorButton(preset) {
     button.style.fontFamily = fontFamily;
   }
 
-  const label = document.createElement("div");
-  label.className = "color-label";
-  const name = document.createElement("strong");
-  name.textContent = preset.name;
-  const source = document.createElement("span");
-  source.textContent = preset.sourcePath;
-  label.append(name, source);
+  button.append(renderPresetPreview(preset));
+  return button;
+}
 
-  button.append(label);
+function renderPresetPreview(preset) {
+  const preview = document.createElement("div");
+  preview.className = "preset-preview";
 
-  if (preset.scheme) {
-    const swatches = document.createElement("div");
-    swatches.className = "swatches";
-    for (const key of schemeKeys.slice(0, 8)) {
-      const swatch = document.createElement("i");
-      swatch.style.backgroundColor = preset.scheme[key];
-      swatches.append(swatch);
-    }
-    button.append(swatches);
+  if (!preset.scheme) {
+    preview.classList.add("preset-preview-default");
+    preview.style.backgroundColor = defaultPttScheme.black;
+    preview.style.color = defaultPttScheme.brightWhite;
+    preview.append(
+      renderPresetArticleLine({
+        markerColor: defaultPttScheme.brightGreen,
+        title: `[配色] ${preset.name}`,
+        source: renderPresetSource(preset),
+      }),
+      renderPresetSampleLine(preset, defaultPttScheme),
+    );
+    return preview;
   }
 
-  return button;
+  const background = schemeColor(preset.scheme, "black", "#000000");
+  const foreground = schemeColor(preset.scheme, "brightWhite", "#ffffff");
+  preview.style.backgroundColor = background;
+  preview.style.color = foreground;
+
+  preview.append(
+    renderPresetArticleLine({
+      markerColor: schemeColor(preset.scheme, "brightGreen", foreground),
+      title: `[配色] ${preset.name}`,
+      source: renderPresetSource(preset),
+    }),
+    renderPresetSampleLine(preset, preset.scheme),
+  );
+
+  return preview;
+}
+
+function renderPresetArticleLine({ markerColor, title, source }) {
+  const article = document.createElement("div");
+  article.className = "preset-preview-article";
+
+  const marker = document.createElement("span");
+  marker.className = "preset-preview-marker";
+  marker.style.color = markerColor;
+  marker.textContent = "●";
+
+  const date = document.createElement("span");
+  date.className = "preset-preview-date";
+  date.textContent = "6/15";
+
+  const titleNode = document.createElement("strong");
+  titleNode.className = "preset-preview-title";
+  titleNode.textContent = title;
+
+  article.append(marker, date, titleNode);
+  if (source) {
+    article.append(source);
+  }
+  return article;
+}
+
+function renderPresetSampleLine(preset, scheme) {
+  const sample = document.createElement("div");
+  sample.className = "preset-preview-samples";
+  sample.append(...pttPreviewSampleGroups.map((group) => renderColorSampleGroup(group, scheme)));
+  return sample;
+}
+
+function renderColorSampleGroup(groupDefinition, scheme) {
+  const group = document.createElement("span");
+  group.className = "ptt-color-sample-group";
+
+  const labelNode = document.createElement("span");
+  labelNode.className = "ptt-color-sample-label";
+  labelNode.textContent = groupDefinition.label;
+
+  group.append(
+    labelNode,
+    ...groupDefinition.cells.map((cell) => renderPttColorSample(cell, scheme)),
+  );
+  return group;
+}
+
+function renderPttColorSample(cell, scheme) {
+  const foreground = schemeColor(scheme, cell.fgKey, defaultPttScheme[cell.fgKey] ?? "#ffffff");
+  const background = schemeColor(scheme, cell.bgKey, defaultPttScheme[cell.bgKey] ?? "#000000");
+  const sample = document.createElement("span");
+  sample.className = "ptt-color-sample";
+  sample.title = `${cell.pttClass}: ${schemeLabels[cell.fgKey]} on ${schemeLabels[cell.bgKey]}`;
+  sample.setAttribute("aria-label", sample.title);
+  sample.style.color = foreground;
+  sample.style.backgroundColor = background;
+  sample.textContent = cell.text;
+
+  return sample;
+}
+
+function renderPresetSource(preset) {
+  const source = document.createElement("span");
+  const sourcePath = preset.sourcePath ?? "term.ptt.cc default";
+  source.className = "preset-preview-source";
+  source.textContent = formatPresetSource(sourcePath);
+  source.title = sourcePath;
+  return source;
+}
+
+function formatPresetSource(sourcePath) {
+  if (!sourcePath) {
+    return "Term PTT";
+  }
+
+  if (sourcePath.startsWith("term.ptt.cc")) {
+    return "Term PTT";
+  }
+
+  const [source] = sourcePath.split("/");
+  if (source === "windowsterminal") {
+    return "WinTerm";
+  }
+
+  return source || "Term PTT";
+}
+
+function schemeColor(scheme, schemeKey, fallback) {
+  return normalizeHex(scheme?.[schemeKey]) ?? fallback;
 }
 
 function selectPreset(preset) {

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -172,6 +172,45 @@ test("extension popup opens the color picker directly from current palette swatc
   assert.doesNotMatch(popupCss, /:has\(\.palette-editor/);
 });
 
+test("extension popup renders presets as PTT-style color previews", async () => {
+  const popupCss = await readFile("extension/popup.css", "utf8");
+  const popupJs = await readFile("extension/popup.js", "utf8");
+  const renderColorButtonBody = extractFunctionBody(popupJs, "renderColorButton");
+
+  assert.match(renderColorButtonBody, /button\.append\(renderPresetPreview\(preset\)\)/);
+  assert.match(popupJs, /function renderPresetPreview\(preset\)/);
+  assert.match(popupJs, /\[配色\]/);
+  assert.match(popupJs, /pttPreviewSampleGroups/);
+  assert.match(popupJs, /pttBrightForegroundKeys/);
+  assert.match(popupJs, /pttDarkBackgroundKeys/);
+  assert.match(popupJs, /label: "黑底"/);
+  assert.match(popupJs, /label: "白字"/);
+  assert.match(popupJs, /pttClass: `q\$\{schemeKeys\.indexOf\(key\)\} b0\/body`/);
+  assert.match(popupJs, /pttClass: `q15 \$\{bgIndex === 0 \? "b0\/body" : `b\$\{bgIndex\}`\}`/);
+  assert.match(popupJs, /function renderPttColorSample/);
+  assert.match(popupJs, /function formatPresetSource/);
+  assert.match(popupJs, /WinTerm/);
+  assert.match(popupJs, /schemeColor\(preset\.scheme, "black"/);
+  assert.match(popupJs, /schemeColor\(preset\.scheme, "brightWhite"/);
+  assert.match(popupJs, /preset-preview-default/);
+  assert.doesNotMatch(popupJs, /textShadow/);
+  assert.doesNotMatch(popupJs, /標題|底紅|底白|爆|推/);
+  assert.doesNotMatch(popupJs, /renderAnsiForeground\("紅"/);
+  assert.doesNotMatch(popupJs, /function renderAnsiPair/);
+  assert.doesNotMatch(popupJs, /className = "swatches"/);
+  assert.match(popupCss, /\.preset-preview\s*{/);
+  assert.match(popupCss, /\.preset-preview-article\s*{/);
+  assert.match(popupCss, /\.preset-preview-title\s*{/);
+  assert.match(popupCss, /\.preset-preview-samples\s*{/);
+  assert.match(popupCss, /\.preset-preview-source\s*{/);
+  assert.match(popupCss, /\.ptt-color-sample-group\s*{/);
+  assert.match(popupCss, /\.ptt-color-sample-label\s*{/);
+  assert.match(popupCss, /\.ptt-color-sample\s*{/);
+  assert.doesNotMatch(popupCss, /\.ptt-cell-sample\s*{/);
+  assert.doesNotMatch(popupCss, /\.ansi-pair\s*{/);
+  assert.doesNotMatch(popupCss, /\.swatches\s*{/);
+});
+
 test("extension popup routes non-term pages to term.ptt.cc", async () => {
   const popupJs = await readFile("extension/popup.js", "utf8");
   const initBody = extractFunctionBody(popupJs, "init");
@@ -206,7 +245,8 @@ test("extension popup keeps scrolling inside the color list", async () => {
   assert.match(popupCss, /\.color-list\s*{[^}]*flex:\s*1 1 auto;[^}]*min-height:\s*0;[^}]*align-content:\s*start;[^}]*overflow-x:\s*hidden;[^}]*overflow-y:\s*auto;[^}]*scrollbar-gutter:\s*stable;/s);
   assert.doesNotMatch(popupCss, /\.color-list\s*{[^}]*max-height:/s);
   assert.match(popupCss, /\.color-button\s*{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\);/s);
-  assert.match(popupCss, /\.swatches\s*{[^}]*justify-content:\s*start;/s);
+  assert.match(popupCss, /\.preset-preview\s*{[^}]*overflow:\s*hidden;/s);
+  assert.match(popupCss, /\.preset-preview-samples\s*{[^}]*overflow:\s*hidden;/s);
   assert.match(popupJs, /renderColors\(\{ scrollIntoView: true \}\)/);
   assert.match(popupJs, /function renderColors\(\{ scrollIntoView = false \} = \{\}\)/);
   assert.match(popupJs, /if \(scrollIntoView\) \{\s*scrollSelectedPresetIntoView\(\);\s*\}/s);

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -193,6 +193,7 @@ test("extension popup renders presets as PTT-style color previews", async () => 
   assert.match(popupJs, /schemeColor\(preset\.scheme, "black"/);
   assert.match(popupJs, /schemeColor\(preset\.scheme, "brightWhite"/);
   assert.match(popupJs, /preset-preview-default/);
+  assert.match(popupJs, /marker\.setAttribute\("aria-hidden", "true"\)/);
   assert.doesNotMatch(popupJs, /textShadow/);
   assert.doesNotMatch(popupJs, /標題|底紅|底白|爆|推/);
   assert.doesNotMatch(popupJs, /renderAnsiForeground\("紅"/);
@@ -206,6 +207,8 @@ test("extension popup renders presets as PTT-style color previews", async () => 
   assert.match(popupCss, /\.ptt-color-sample-group\s*{/);
   assert.match(popupCss, /\.ptt-color-sample-label\s*{/);
   assert.match(popupCss, /\.ptt-color-sample\s*{/);
+  assert.match(popupCss, /color-mix\(in srgb, var\(--accent\) 36%, transparent\)/);
+  assert.doesNotMatch(popupCss, /rgba\(17,\s*184,\s*159/);
   assert.doesNotMatch(popupCss, /\.ptt-cell-sample\s*{/);
   assert.doesNotMatch(popupCss, /\.ansi-pair\s*{/);
   assert.doesNotMatch(popupCss, /\.swatches\s*{/);


### PR DESCRIPTION
## Summary
- Restyle the popup with a compact terminal/retro visual treatment.
- Render color presets as PTT-style rows with text-on-background samples instead of plain swatches.
- Shorten preset source labels and keep full source paths in hover titles.
- Add static coverage for the popup preset preview structure.

## Verification
- pnpm verify
- Refreshed the local tmp-profile popup preview and checked the preset rows for overflow.