### PR TITLE
feat: add popup repository link

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,3 +15,10 @@ This project generates and references data from third-party open-source projects
 - Use: planned source for a processed PTT-compatible font preset in `data/fonts.json`
 - License: MIT License
 - Bundling status: no Fusion Pixel font files are bundled in this extension package
+
+## Primer Octicons
+
+- Repository: [primer/octicons](https://github.com/primer/octicons)
+- Use: inline GitHub mark icon in `extension/popup.html`
+- Copyright: GitHub Inc.
+- License: MIT License

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -44,10 +44,18 @@ select {
 }
 
 .header {
+  display: flex;
   flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
   margin-bottom: 10px;
   padding-bottom: 10px;
   border-bottom: 1px solid var(--line);
+}
+
+.header-copy {
+  min-width: 0;
 }
 
 h1 {
@@ -61,6 +69,35 @@ p {
   margin: 4px 0 0;
   color: var(--muted);
   font-size: 11px;
+}
+
+.repository-button {
+  display: inline-grid;
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0;
+  background: var(--field);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.repository-button:hover {
+  border-color: var(--line-strong);
+  color: var(--ink);
+}
+
+.repository-button:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 36%, transparent);
+  outline-offset: 1px;
+}
+
+.repository-icon {
+  display: block;
 }
 
 .controls {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -9,10 +9,21 @@
   <body>
     <main class="popup">
       <header class="header">
-        <div>
+        <div class="header-copy">
           <h1>Term PTT Custom Theme</h1>
           <p id="status">Loading colors and fonts...</p>
         </div>
+        <button
+          id="repositoryButton"
+          class="repository-button"
+          type="button"
+          title="Open project repository"
+          aria-label="Open project repository on GitHub"
+        >
+          <svg class="repository-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.03 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.06-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.45.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
+          </svg>
+        </button>
       </header>
 
       <section id="controls" class="controls" hidden>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,4 +1,5 @@
 const statusNode = document.getElementById("status");
+const repositoryButton = document.getElementById("repositoryButton");
 const controlsNode = document.getElementById("controls");
 const searchInput = document.getElementById("searchInput");
 const fontSelect = document.getElementById("fontSelect");
@@ -10,6 +11,7 @@ const paletteStripNode = document.getElementById("paletteStrip");
 const colorListNode = document.getElementById("colorList");
 const applyButton = document.getElementById("applyButton");
 
+const REPOSITORY_URL = "https://github.com/VdustR/term-ptt-custom-theme";
 const TERM_PTT_URL = "https://term.ptt.cc/";
 const TERM_PTT_PATTERN = "https://term.ptt.cc/*";
 const DEFAULT_COLORS_ID = "term-ptt-default";
@@ -138,6 +140,7 @@ let selectedFont = null;
 let savedFont = null;
 let persistDraftTimeout = null;
 
+repositoryButton.addEventListener("click", openRepository);
 window.addEventListener("pagehide", flushPendingDraftWrite);
 init();
 
@@ -218,6 +221,15 @@ async function routeToTermPtt() {
     window.close();
   } catch {
     statusNode.textContent = "Could not open term.ptt.cc.";
+  }
+}
+
+async function openRepository() {
+  try {
+    await chrome.tabs.create({ url: REPOSITORY_URL, active: true });
+    window.close();
+  } catch {
+    statusNode.textContent = "Could not open repository.";
   }
 }
 

--- a/test/pages-workflow.test.mjs
+++ b/test/pages-workflow.test.mjs
@@ -88,21 +88,30 @@ test("extension-only scope does not include marketplace handoff surfaces", async
   assert.equal(packageJson.scripts["configure:marketplace"], undefined);
   assert.equal(Object.hasOwn(manifest, "externally_connectable"), false);
   assert.equal(Object.hasOwn(manifest, "background"), false);
+  assert.equal(manifest.permissions.includes("tabs"), false);
   assert.doesNotMatch(popupHtml, /marketplaceLink|Store|vdustr\.github\.io/);
   assert.doesNotMatch(popupJs, /pendingMarketplace|from Store/);
 });
 
 test("extension popup browses colors and fonts inside the extension", async () => {
   const popupHtml = await readFile("extension/popup.html", "utf8");
+  const popupCss = await readFile("extension/popup.css", "utf8");
   const popupJs = await readFile("extension/popup.js", "utf8");
 
   assert.match(popupHtml, /fontSelect/);
+  assert.match(popupHtml, /repositoryButton/);
+  assert.match(popupHtml, /Open project repository on GitHub/);
   assert.match(popupHtml, /currentPaletteName/);
   assert.match(popupHtml, /modifiedBadge/);
   assert.match(popupHtml, /paletteStrip/);
   assert.match(popupHtml, /colorList/);
   assert.match(popupJs, /fetch\("assets\/colors\.json"\)/);
   assert.match(popupJs, /fetch\("assets\/fonts\.json"\)/);
+  assert.match(popupJs, /const REPOSITORY_URL = "https:\/\/github\.com\/VdustR\/term-ptt-custom-theme";/);
+  assert.match(popupJs, /repositoryButton\.addEventListener\("click", openRepository\)/);
+  assert.match(popupJs, /chrome\.tabs\.create\(\{ url: REPOSITORY_URL, active: true \}\)/);
+  assert.match(popupCss, /\.header\s*{[^}]*align-items:\s*center;/s);
+  assert.match(popupCss, /\.repository-button\s*{[^}]*padding:\s*0;/s);
   assert.match(popupJs, /selectedFont/);
   assert.match(popupJs, /DEFAULT_COLORS_ID = "term-ptt-default"/);
   assert.match(popupJs, /DEFAULT_FONT_ID = "term-ptt-default"/);

--- a/test/third-party-notices.test.mjs
+++ b/test/third-party-notices.test.mjs
@@ -13,6 +13,9 @@ test("third-party notices cover generated colors and planned font sources", asyn
   assert.match(notices, /individual scheme rights belong to original authors/);
   assert.match(notices, /TakWolf\/fusion-pixel-font/);
   assert.match(notices, /Fusion Pixel/);
+  assert.match(notices, /Primer Octicons/);
+  assert.match(notices, /primer\/octicons/);
+  assert.match(notices, /inline GitHub mark icon/);
   assert.equal(colors.colors[0].license, "MIT collection; individual scheme rights belong to original authors");
   assert.equal(fusionPixel.source.license, "MIT");
 });


### PR DESCRIPTION
## Summary
- Add a compact GitHub repository icon button to the popup header.
- Open the project repository in a new tab without adding new extension permissions.
- Document the inline Primer Octicons GitHub mark in third-party notices.

## Verification
- pnpm verify
- Headless popup layout check for centered icon and no body scroll regression